### PR TITLE
Fix missing response in GET /api/codes/[id]

### DIFF
--- a/app/api/codes/[id]/route.ts
+++ b/app/api/codes/[id]/route.ts
@@ -1,29 +1,39 @@
 import { prisma } from "@/shared/lib/prisma";
+import { NextResponse } from "next/server";
 
-export default async function GET(
-	req: Request,
-	{ params }: { params: Promise<{ id: string }> },
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
 ) {
-	const { id } = await params;
-	const generatedCode = await prisma.generatedCodePack.findUnique({
-		where: { id },
-		select: {
-			codes: {
-				select: {
-					value: true,
-				},
-			},
-			nomenclature: {
-				select: {
-					name: true,
-					modelArticle: true,
-					size: true,
-					color: true,
-				},
-			},
-		},
-	});
-	if (!generatedCode) {
-		return new Response(null, { status: 404 });
-	}
+  const { id } = params;
+
+  const generatedCode = await prisma.generatedCodePack.findUnique({
+    where: { id },
+    select: {
+      codes: {
+        select: {
+          value: true,
+        },
+      },
+      nomenclature: {
+        select: {
+          name: true,
+          modelArticle: true,
+          color: true,
+          sizeGtin: {
+            select: {
+              size: true,
+              gtin: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!generatedCode) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(generatedCode);
 }


### PR DESCRIPTION
## Summary
- return data for GET `/api/codes/[id]`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840b7d2465c8320a91fdedcb1917ac2