### PR TITLE
Add code links page with lookup feature

### DIFF
--- a/app/api/code-links/route.ts
+++ b/app/api/code-links/route.ts
@@ -1,0 +1,59 @@
+import { prisma } from "@/shared/lib/prisma";
+import { NextResponse } from "next/server";
+
+function normalizeScannerInput(raw: string): string {
+  const GS = String.fromCharCode(29);
+  return `�${raw.split(GS).join("\\x1D")}`;
+}
+
+export async function POST(req: Request) {
+  try {
+    const { code } = await req.json();
+    if (!code) {
+      return NextResponse.json({ error: "Введите код!" }, { status: 400 });
+    }
+    const formatted = normalizeScannerInput(code);
+
+    const pack = await prisma.generatedCodePack.findUnique({
+      where: { value: formatted },
+      include: { codes: true, nomenclature: true },
+    });
+    if (pack) {
+      return NextResponse.json({
+        generatedCodePack: {
+          value: pack.value,
+          nomenclature: pack.nomenclature,
+          codes: pack.codes,
+        },
+      });
+    }
+
+    const foundCode = await prisma.code.findFirst({
+      where: { formattedValue: formatted },
+      include: {
+        generatedCodePack: { include: { codes: true, nomenclature: true } },
+      },
+    });
+
+    if (!foundCode || !foundCode.generatedCodePack) {
+      return NextResponse.json(
+        { error: "Код не найден или не привязан к агрегированному коду!" },
+        { status: 404 },
+      );
+    }
+
+    const gPack = foundCode.generatedCodePack;
+    return NextResponse.json({
+      generatedCodePack: {
+        value: gPack.value,
+        nomenclature: gPack.nomenclature,
+        codes: gPack.codes,
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Ошибка сервера. Попробуйте позже." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/code-links/LinkedCodesTable.tsx
+++ b/app/code-links/LinkedCodesTable.tsx
@@ -1,28 +1,23 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useState } from "react";
-
-const Select = dynamic(() => import("react-select"), { ssr: false });
-
-function LinkedCodesTable({ linkedCodes = [] }: { linkedCodes?: string[] }) {
-	const [codes, setCodes] = useState<string[]>(linkedCodes);
-
-	return (
-		<div className="w-full gap-4 flex flex-col print:hidden">
-			<div className="flex flex-row w-full rounded-lg border border-blue-300 bg-white px-8 py-3 gap-4">
-				<div className="w-1/2 flex flex-col">
-					<ul>
-						{codes.map((code, index) => (
-							<li key={code} className="border-b border-gray-200 py-2">
-								{code}
-							</li>
-						))}
-					</ul>
-				</div>
-			</div>
-		</div>
-	);
+interface Props {
+  linkedCodes: string[];
 }
 
-export default LinkedCodesTable;
+export default function LinkedCodesTable({ linkedCodes }: Props) {
+  return (
+    <div className="w-full gap-4 flex flex-col print:hidden">
+      <div className="flex flex-row w-full rounded-lg border border-blue-300 bg-white px-8 py-3 gap-4">
+        <div className="w-1/2 flex flex-col">
+          <ul>
+            {linkedCodes.map((code) => (
+              <li key={code} className="border-b border-gray-200 py-2">
+                {code}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/code-links/page.tsx
+++ b/app/code-links/page.tsx
@@ -1,19 +1,22 @@
 "use client";
 
+import { useState } from "react";
 import { withRole } from "@/shared/configs/withRole";
 import Layout from "@/shared/ui/Layout";
 import CodeLinksTable from "./CodeLinksTable";
 import LinkedCodesTable from "./LinkedCodesTable";
 
-const CompaniesPage = () => {
-	return (
-		<Layout className="flex-col">
-			<CodeLinksTable />
-			<LinkedCodesTable />
-		</Layout>
-	);
-};
+function CodeLinksPage() {
+  const [codes, setCodes] = useState<string[]>([]);
 
-export default withRole(CompaniesPage, {
-	allowedRoles: ["ADMIN", "COMPANY_ADMIN", "COMPANY_USER"],
+  return (
+    <Layout className="flex-col">
+      <CodeLinksTable onLinkedCodes={setCodes} />
+      <LinkedCodesTable linkedCodes={codes} />
+    </Layout>
+  );
+}
+
+export default withRole(CodeLinksPage, {
+  allowedRoles: ["ADMIN", "COMPANY_ADMIN", "COMPANY_USER"],
 });


### PR DESCRIPTION
## Summary
- add `/api/code-links` endpoint for linking codes
- implement CodeLinksTable to fetch linked codes with debounce and toast errors
- show results in LinkedCodesTable
- wire new functionality in `code-links` page

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5fdc7c083208aa11ee87857b7a3