### PR TITLE
Update code links tables

### DIFF
--- a/app/code-links/CodeLinksTable.tsx
+++ b/app/code-links/CodeLinksTable.tsx
@@ -1,18 +1,23 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { NomenclatureOption } from "@/aggregation/model/types";
 import { toast } from "react-toastify";
 
 interface Props {
   onLinkedCodes: (codes: string[]) => void;
+  onNomenclature: (nom: NomenclatureOption | null) => void;
 }
 
-export default function CodeLinksTable({ onLinkedCodes }: Props) {
+export default function CodeLinksTable({ onLinkedCodes, onNomenclature }: Props) {
   const [inputCode, setInputCode] = useState("");
+  const [modelArticle, setModelArticle] = useState("");
 
   useEffect(() => {
     if (!inputCode) {
       onLinkedCodes([]);
+      onNomenclature(null);
+      setModelArticle("");
       return;
     }
     const timeout = setTimeout(async () => {
@@ -26,10 +31,15 @@ export default function CodeLinksTable({ onLinkedCodes }: Props) {
         if (!response.ok) {
           toast.error(data.error);
           onLinkedCodes([]);
+          onNomenclature(null);
+          setModelArticle("");
         } else {
-          onLinkedCodes(
-            data.generatedCodePack.codes.map((c: { value: string }) => c.value),
-          );
+          setModelArticle(data.generatedCodePack.nomenclature?.modelArticle || "");
+          onNomenclature(data.generatedCodePack.nomenclature || null);
+          onLinkedCodes([
+            data.generatedCodePack.value,
+            ...data.generatedCodePack.codes.map((c: { value: string }) => c.value),
+          ]);
         }
       } catch {
         toast.error("Ошибка сервера. Попробуйте позже.");
@@ -37,7 +47,7 @@ export default function CodeLinksTable({ onLinkedCodes }: Props) {
       }
     }, 1000);
     return () => clearTimeout(timeout);
-  }, [inputCode, onLinkedCodes]);
+  }, [inputCode, onLinkedCodes, onNomenclature]);
 
   return (
     <div className="w-full gap-4 flex flex-col print:hidden">
@@ -55,6 +65,16 @@ export default function CodeLinksTable({ onLinkedCodes }: Props) {
             value={inputCode}
             onChange={(e) => setInputCode(e.target.value)}
             className="border border-gray-300 rounded-lg px-3 py-2"
+          />
+        </div>
+        <div className="w-1/2 flex flex-col">
+          <label htmlFor="modelArticle">Модель</label>
+          <input
+            id="modelArticle"
+            type="text"
+            readOnly
+            value={modelArticle}
+            className="border border-gray-300 rounded-lg px-3 py-2 bg-gray-100"
           />
         </div>
       </div>

--- a/app/code-links/LinkedCodesTable.tsx
+++ b/app/code-links/LinkedCodesTable.tsx
@@ -1,18 +1,37 @@
 "use client";
 
+import type { NomenclatureOption } from "@/aggregation/model/types";
+import { PrintIcon } from "@/shared/ui/icons";
+import { usePrintStore } from "@/shared/store/printStore";
+
 interface Props {
   linkedCodes: string[];
+  nomenclature: NomenclatureOption | null;
 }
 
-export default function LinkedCodesTable({ linkedCodes }: Props) {
+export default function LinkedCodesTable({ linkedCodes, nomenclature }: Props) {
+  const { setPrintCodes, setSize, triggerPrint } = usePrintStore();
+
+  const handlePrint = (code: string) => {
+    setPrintCodes([code]);
+    if (nomenclature?.size) setSize(nomenclature.size);
+    triggerPrint();
+  };
   return (
     <div className="w-full gap-4 flex flex-col print:hidden">
       <div className="flex flex-row w-full rounded-lg border border-blue-300 bg-white px-8 py-3 gap-4">
         <div className="w-1/2 flex flex-col">
           <ul>
             {linkedCodes.map((code) => (
-              <li key={code} className="border-b border-gray-200 py-2">
-                {code}
+              <li key={code} className="border-b border-gray-200 py-2 flex items-center justify-between gap-2">
+                <span>{code}</span>
+                <button
+                  type="button"
+                  onClick={() => handlePrint(code)}
+                  className="p-2 rounded-md hover:bg-gray-100"
+                >
+                  <PrintIcon className="size-5 stroke-blue-600 fill-none stroke-2" />
+                </button>
               </li>
             ))}
           </ul>

--- a/app/code-links/page.tsx
+++ b/app/code-links/page.tsx
@@ -5,14 +5,28 @@ import { withRole } from "@/shared/configs/withRole";
 import Layout from "@/shared/ui/Layout";
 import CodeLinksTable from "./CodeLinksTable";
 import LinkedCodesTable from "./LinkedCodesTable";
+import PrintCodes from "@/components/aggregation-codes/PrintCodes";
+import { usePrintTemplate } from "@/nomenclature/hooks/usePrintTemplate";
+import type { NomenclatureOption } from "@/aggregation/model/types";
 
 function CodeLinksPage() {
   const [codes, setCodes] = useState<string[]>([]);
+  const [nomenclature, setNomenclature] = useState<NomenclatureOption | null>(null);
+  const { data: printTemplate } = usePrintTemplate();
 
   return (
     <Layout className="flex-col">
-      <CodeLinksTable onLinkedCodes={setCodes} />
-      <LinkedCodesTable linkedCodes={codes} />
+      <CodeLinksTable
+        onLinkedCodes={setCodes}
+        onNomenclature={setNomenclature}
+      />
+      <LinkedCodesTable linkedCodes={codes} nomenclature={nomenclature} />
+      {printTemplate && (
+        <PrintCodes
+          printTemplate={printTemplate}
+          selectedNomenclature={nomenclature}
+        />
+      )}
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- show linked pack first and display nomenclature info
- enable printing from linked code rows
- expose print helpers on code-links page
- clear nomenclature when the code input is empty

## Testing
- `npm run lint` *(fails: ESLint errors)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b658956c88320bff4eb0daf31d237